### PR TITLE
SB-415 upgrade node version in circleci-ruby repo (11 to 18)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,17 @@ RUN sudo apt-get install \
 
 # Install Node.js and Yarn for Webpack(er)
 RUN \
-  sudo curl -sL https://deb.nodesource.com/setup_11.x | sudo bash - && \
+  sudo curl -sL https://deb.nodesource.com/setup_18.x | sudo bash - && \
   sudo apt-get install -y nodejs && \
   sudo curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
-  sudo apt-get update && sudo apt-get install yarn    
-      
+  sudo apt-get update && sudo apt-get install yarn
+
 # Install AWS CLI
 RUN sudo curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
   sudo unzip awscliv2.zip && \
   sudo ./aws/install && \
-  aws --version 
+  aws --version
 
 # Install nginx
 RUN sudo apt-get update && \


### PR DESCRIPTION
raises a version number and has a bunch of whitespace stuff for whatever reason